### PR TITLE
Uses of unsafe C functions have been replaced by secure alternatives …

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,13 @@ All code compiles with g++ version 7.4.
 
 It includes a _make_ based build system in files named Makefile\*. To build **hipserver**, move to this folder and type 'make'.  The executable output file lands in this folder and is named **hipserver**.
 
-The reopsitory contains four folders:
+The reopsitory contains five folders:
 
 * Server
 * AppConnect
 * Common
 * Realtime
+* [safestringlib](https://github.com/intel/safestringlib)
 
 #### Server
 
@@ -136,5 +137,7 @@ This folder contains headers defining data types, error values and other enumera
 #### Realtime
 This folder contains library code for managing signals, semaphores, threads and POSIX message queues.
 
+#### safestringlib
+This folder contains an adapted version of Intel's library from GitHub.  See the README file in that folder for more information.
 
 

--- a/hipserver/AppConnect/appmsg.h
+++ b/hipserver/AppConnect/appmsg.h
@@ -40,6 +40,7 @@
 
 #include <string.h>
 #include "tpdll.h"
+#include "safe_lib.h"
 
 #define HART_APP_CMD	0
 #define INIT_APP_CMD	1
@@ -54,14 +55,14 @@ struct AppMsg
 	uint8_t pdu[TPPDU_MAX_FRAMELEN];	// HART TP PDU or APP PDU
 
 	// command and transaction need to stay..void clear() { memset( this, 0, APP_MSG_SIZE); };
-	void clear() { memset(pdu, 0, TPPDU_MAX_FRAMELEN); };//leave cmd & transaction
+	void clear() { memset_s(pdu, TPPDU_MAX_FRAMELEN, 0); };//leave cmd & transaction
 	AppMsg& operator=(const AppMsg &SRC) {command = SRC.command;
-			transaction = SRC.transaction; memcpy(&pdu[0],&(SRC.pdu[0]),TPPDU_MAX_FRAMELEN);
+			transaction = SRC.transaction; memcpy_s(&pdu[0],TPPDU_MAX_FRAMELEN, &(SRC.pdu[0]),TPPDU_MAX_FRAMELEN);
 			return *this;   };
 
 	uint8_t *GetPduBuffer()   { return pdu; };
-	void     ClearPduBuffer() { memset(pdu, 0, sizeof(pdu)); };
-	void     CopyPduBuffer(uint8_t *to ) { memcpy(to, pdu, sizeof(pdu)); };
+	void     ClearPduBuffer() { memset_s(pdu, sizeof(pdu), 0); };
+	void     CopyPduBuffer(uint8_t *to ) { memcpy_s(to, TPPDU_MAX_FRAMELEN, pdu, sizeof(pdu)); };
 };
 
 

--- a/hipserver/AppConnect/apppdu.cpp
+++ b/hipserver/AppConnect/apppdu.cpp
@@ -32,7 +32,7 @@ AppPdu::AppPdu()
 void AppPdu::copy( const AppPdu &src )
 {
 	shrtAddr = src.shrtAddr;
-	memcpy(&(longAddr[0]), &(src.longAddr[0]), 5);
+	memcpy_s(&(longAddr[0]), sizeof(longAddr), &(src.longAddr[0]), sizeof(src.longAddr));
 	bytesLoaded = src.bytesLoaded;
 	AppMsg * pMsg = dynamic_cast<AppMsg *>(this);
 	*pMsg = src;    // operator=
@@ -119,7 +119,7 @@ bool AppPdu::isPrimary()
 void AppPdu::setupAddress( uint8_t newDelim )
 {
 	pdu[TP_OFFSET_DELIM] = newDelim;
-	memcpy( &(pdu[TP_OFFSET_ADDR]), longAddr, 5 );
+	memcpy_s( &(pdu[TP_OFFSET_ADDR]), TPHDR_ADDRLEN_UNIQ, longAddr, TPHDR_ADDRLEN_UNIQ );
 	pdu[TP_OFFSET_CMD_UNIQ] = 0;
 }
 
@@ -134,8 +134,8 @@ void AppPdu::learnAddress()
 		int deviceIdByte = 9;
 		int deviceIdSize = 3;
 
-		memcpy(ln, ResponseBytes()+expDeviceTypeByte, expDeviceTypeSize);	// expanded device type
-		memcpy(ln+expDeviceTypeSize, ResponseBytes()+deviceIdByte, deviceIdSize);	// device ID
+		memcpy_s(ln, TPHDR_ADDRLEN_UNIQ, ResponseBytes() + expDeviceTypeByte, expDeviceTypeSize); 	// expanded device type
+		memcpy_s(ln+expDeviceTypeSize, deviceIdSize, ResponseBytes()+deviceIdByte, deviceIdSize);	// device ID
 
 		setLong(ln);
 		setShort(*Address());

--- a/hipserver/AppConnect/apppdu.h
+++ b/hipserver/AppConnect/apppdu.h
@@ -78,7 +78,7 @@ public: // accessors
 	uint8_t *myAddress() {  return  IsLongFrame()?&(longAddr[0]):&(shrtAddr); };
 	bool    isPrimary();// 4devices  host address, false: secondary
 	void setShort(uint8_t poll) { shrtAddr= poll; };
-	void setLong(uint8_t lng[]){ memcpy(longAddr, lng, 5); };
+	void setLong(uint8_t lng[]){ memcpy_s(longAddr, TPHDR_ADDRLEN_UNIQ, lng, TPHDR_ADDRLEN_UNIQ); };
 	void learnAddress();
 };
 

--- a/hipserver/AppConnect/tpdll.h
+++ b/hipserver/AppConnect/tpdll.h
@@ -101,9 +101,9 @@
  * TPDLL Header (8) + DataBytes (255) + CheckByte (1)
  * (8 hdr = 1 delim + 5 addr + 0 exp + 1 cmd + 1 byte count)
  */
-#define TPPDU_MAX_FRAMELEN       (TPPDU_MAX_HDRLEN   +   \
+#define TPPDU_MAX_FRAMELEN       ( (TPPDU_MAX_HDRLEN   +   \
                                   TPPDU_MAX_DATALEN  +   \
-                                  TPPDU_MAX_CHECKSUMLEN)
+                                  TPPDU_MAX_CHECKSUMLEN))
 
 
 /* Values of the sub-fields of the TPDLL Delimiter */

--- a/hipserver/AppConnect/tppdu.h
+++ b/hipserver/AppConnect/tppdu.h
@@ -36,6 +36,7 @@
 
 #include "tpdll.h"
 #include "hartdefs.h"
+#include "safe_lib.h"
 
 #include <string.h>
 
@@ -61,7 +62,7 @@ public:
 	;
 	void SetStore(uint8_t *data)
 	{
-		memcpy(pdustore, (const void *) data, TPPDU_MAX_FRAMELEN);
+		memcpy_s(pdustore, TPPDU_MAX_FRAMELEN, (const void *) data, TPPDU_MAX_FRAMELEN);
 	}
 	;
 	uint8_t *Store()

--- a/hipserver/Realtime/toolqueues.cpp
+++ b/hipserver/Realtime/toolqueues.cpp
@@ -111,7 +111,7 @@ int highest_instance_number()
 	return highest;
 }
 
-string make_mq_name(const char *basename, char *instance /*, char *fname*/)
+string make_mq_name(const char *basename, char *instance)
 {
   string u = "_";
   string s = basename + u + instance;

--- a/hipserver/Realtime/toolqueues.cpp
+++ b/hipserver/Realtime/toolqueues.cpp
@@ -116,8 +116,6 @@ string make_mq_name(const char *basename, char *instance /*, char *fname*/)
   string u = "_";
   string s = basename + u + instance;
   return s;
-
-//	sprintf(fname, "%s_%s", basename, instance);
 }
 
 /*****************************

--- a/hipserver/Realtime/toolqueues.h
+++ b/hipserver/Realtime/toolqueues.h
@@ -25,10 +25,13 @@
 #ifndef _TOOLQUEUES_H_
 #define _TOOLQUEUES_H_
 
+using namespace std;
+
 #include <mqueue.h>
 
 #include "datatypes.h"
 #include "errval.h"
+#include <string>
 
 /****************
  *  Definitions
@@ -105,7 +108,7 @@ extern mqd_t reqQueue;  // HART request messages routed to device
  *  Function Prototypes
  ************************/
 int highest_instance_number();
-void make_mq_name(const char *basename, char *instance, char *fname);
+string make_mq_name(const char *basename, char *instance);
 
 errVal_t open_mqueue(mqd_t *p_mqDesc, char *mqName, int32_t qFlag,
 		int32_t msgsize, int32_t maxmsg);

--- a/hipserver/Realtime/toolsems.c
+++ b/hipserver/Realtime/toolsems.c
@@ -133,6 +133,22 @@ uint8_t get_sem_count(void)
   return (numSems);
 }
 
+/* This should be deleted once sem_wait_gdb is examined! */
+uint8_t get_sem_name(sem_t *p_sem, char *semName)
+{
+  uint8_t n, found = FALSE;
+
+  for (n = 0; n < numSems; n++)
+  {
+    if (p_sem == htoolSems[n].p_sem)
+    {
+      strcpy(semName, htoolSems[n].semName);
+      found = TRUE;
+      break;
+    }
+  }
+  return (found);
+}
 
 sem_t *open_a_semaphore(const char *semName, uint8_t createFlag,
     uint8_t initVal)

--- a/hipserver/Realtime/toolsems.c
+++ b/hipserver/Realtime/toolsems.c
@@ -35,6 +35,8 @@
 #include "toolsems.h"
 #include "toolutils.h"
 
+#include "safe_lib.h"
+
 /************
  *  Globals
  ************/
@@ -131,22 +133,6 @@ uint8_t get_sem_count(void)
   return (numSems);
 }
 
-/* This should be deleted once sem_wait_gdb is examined! */
-uint8_t get_sem_name(sem_t *p_sem, char *semName)
-{
-  uint8_t n, found = FALSE;
-
-  for (n = 0; n < numSems; n++)
-  {
-    if (p_sem == htoolSems[n].p_sem)
-    {
-      strcpy(semName, htoolSems[n].semName);
-      found = TRUE;
-      break;
-    }
-  }
-  return (found);
-}
 
 sem_t *open_a_semaphore(const char *semName, uint8_t createFlag,
     uint8_t initVal)

--- a/hipserver/Realtime/toolsems.h
+++ b/hipserver/Realtime/toolsems.h
@@ -65,6 +65,7 @@ extern "C" {
 errVal_t create_semaphores(uint8_t createFlag);
 void delete_semaphores(void);
 uint8_t get_sem_count(void);
+uint8_t get_sem_name(sem_t *p_sem, char *semName);
 sem_t *open_a_semaphore(const char *semName, uint8_t createFlag,
 		uint8_t initVal);
 int sem_wait_nointr(sem_t *sem);

--- a/hipserver/Realtime/toolsems.h
+++ b/hipserver/Realtime/toolsems.h
@@ -65,7 +65,6 @@ extern "C" {
 errVal_t create_semaphores(uint8_t createFlag);
 void delete_semaphores(void);
 uint8_t get_sem_count(void);
-uint8_t get_sem_name(sem_t *p_sem, char *semName);
 sem_t *open_a_semaphore(const char *semName, uint8_t createFlag,
 		uint8_t initVal);
 int sem_wait_nointr(sem_t *sem);

--- a/hipserver/Realtime/toolthreads.c
+++ b/hipserver/Realtime/toolthreads.c
@@ -94,12 +94,8 @@ void delete_threads(void)
                 (char *) thrName);
           }
         }
-        else
-        {
-          //print_to_both(p_toolLogPtr,
-          //    "Error in pthread_cancel() for %s!! \n",
-          //    (char *) thrName);
-        }
+        // else nothing
+
       } // if (thrID != NULL)
     } /* for */
     dbgp_logdbg("Total %d threads deleted\n", n);

--- a/hipserver/Realtime/toolthreads.c
+++ b/hipserver/Realtime/toolthreads.c
@@ -96,9 +96,9 @@ void delete_threads(void)
         }
         else
         {
-          print_to_both(p_toolLogPtr,
-              "Error in pthread_cancel() for %s!! \n",
-              (char *) thrName);
+          //print_to_both(p_toolLogPtr,
+          //    "Error in pthread_cancel() for %s!! \n",
+          //    (char *) thrName);
         }
       } // if (thrID != NULL)
     } /* for */

--- a/hipserver/Realtime/toolutils.c
+++ b/hipserver/Realtime/toolutils.c
@@ -40,7 +40,8 @@
 #include "toolsems.h"
 #include "toolthreads.h"
 #include "toolutils.h"
-
+#include "safe_lib.h"
+#include "snprintf_s.h"
 
 /************
  *  Globals
@@ -105,7 +106,7 @@ errVal_t open_logfile(FILE **pp_filePtr, char *p_fileName)
     fprintf(stderr, "\n----------------------------------\n");
     fprintf(stderr, "  Opening %s...\n", p_fileName);
 #endif
-    *pp_filePtr = fopen(p_fileName, "w");
+    *pp_filePtr = fopen(p_fileName, "w"); // filename is string constant in calling func
     if (*pp_filePtr == NULL)
     {
       *pp_filePtr = stderr;
@@ -146,7 +147,7 @@ errVal_t open_toolLog(void)
   if (p_toolLogPtr == NULL)
   {
     /* Log does not exist yet */
-    strcat(TOOLLOG_NAME, "_log.txt");
+    strcat_s(TOOLLOG_NAME, sizeof(TOOLLOG_NAME), "_log.txt");
     errval = open_logfile(&p_toolLogPtr, TOOLLOG_NAME);
   } /* if (p_toolLogPtr == NULL) */
   else
@@ -178,17 +179,19 @@ void print_hexbytes(uint8_t *bytes, uint8_t numBytes, FILE *fptr)
 }
 
 
+
 void print_to_both(FILE *p_log, const char *format, ...)
 {
   /* Format the data and print it both to the log and the screen */
   va_list args;
   va_start(args, format);
 
-  char buffer[1024];
-  memset(buffer, 0, sizeof(buffer));
-  vsnprintf(buffer, 1024, format, args);
+  const int bufsize = 1024;
+  char buffer[bufsize];
+  memset_s(buffer, sizeof(buffer), 0);
+  vsnprintf(buffer, bufsize, format, args);
 
-  if (strlen(buffer) > 0)
+  if (strnlen_s(buffer, bufsize) > 0)
   {
     if (p_log == NULL)
     {
@@ -217,11 +220,12 @@ void print_to_log(FILE *p_filePtr, const char *format, ...)
 	  va_list args;
 	  va_start(args, format);
 
-	  char buffer[1024];
-	  memset(buffer, 0, sizeof(buffer));
-	  vsnprintf(buffer, 1024, format, args);
+    const int bufsize = 1024;
+	  char buffer[bufsize];
+	  memset_s(buffer, bufsize, 0);
+	  vsnprintf(buffer, bufsize, format, args);
 
-	  if (strlen(buffer) > 0)
+	  if (strnlen_s(buffer, bufsize) > 0)
 	  {
 	    if (p_filePtr == NULL)
 	    {

--- a/hipserver/Server/Makefile
+++ b/hipserver/Server/Makefile
@@ -32,10 +32,11 @@ DIR_HSRVR = $(shell cd ..; pwd)
 DIR_APPC = $(DIR_HSRVR)/AppConnect
 DIR_COMN = $(DIR_HSRVR)/Common
 DIR_RLTM = $(DIR_HSRVR)/Realtime
+DIR_SAFE = $(DIR_HSRVR)/safestringlib
 # subdir DIR_SRVR is already defined at top
 
 # Leave RHS blank if no subdirs to be built
-SUBDIRS_HSRVR = $(DIR_APPC) $(DIR_COMN) $(DIR_RLTM) $(DIR_SRVR)
+SUBDIRS_HSRVR = $(DIR_APPC) $(DIR_COMN) $(DIR_RLTM) $(DIR_SRVR) $(DIR_SAFE)
 hsrvr_children = 
 
 # include the various Makefile.inc files in the directory
@@ -56,20 +57,27 @@ EXEC_TOP  = all
 
 $(EXEC_TOP): $(COMMON_OBJS)
 	$(ECHO)
+	cd ../safestringlib && $(MAKE)
+	cd ..
+	$(ECHO)
 	$(ECHO) Building $(EXEC_TOP)
 	$(ECHO)
 	$(LD) $(CFLAGS) -o $(EXEC_NAME) $(OBJS_ALL) $(INCL_LIBS)
 	$(ECHO)
 
+
 # ===============================================================
 
 .PHONY: clean
 clean:
+
 	$(ECHO)
 	$(RM) -f $(EXEC_NAME)      >  /dev/null 2>&1
 	$(RM) -f *.gch             >  /dev/null 2>&1
 	$(RM) -f *.o               >  /dev/null 2>&1
 	@-for d in $(SUBDIRS_HSRVR); do ( echo Cleaning $$d; cd $$d; rm -f *.o; echo ); done
+	cd ../safestringlib && $(MAKE) clean
+	cd ..
 		
 .PHONY: cleanall
 cleanall:

--- a/hipserver/Server/Makefile_macros.inc
+++ b/hipserver/Server/Makefile_macros.inc
@@ -26,10 +26,10 @@
 
 CC        = g++ -c
 CXX        = g++ -c
-CFLAGS     = -g -DLINUX -I. -I../Common  -I../Realtime  -I../AppConnect
-CXXFLAGS   = -g -DLINUX -I. -I../Common  -I../Realtime  -I../AppConnect
+CFLAGS     = -g -DLINUX -I. -I../Common  -I../Realtime  -I../AppConnect  -I../safestringlib/include
+CXXFLAGS   = -g -DLINUX -I. -I../Common  -I../Realtime  -I../AppConnect  -I../safestringlib/include
 ECHO       = @echo
-INCL_LIBS  = -lpthread -lrt
-LD         = g++
+INCL_LIBS  = -lpthread -lrt   ../safestringlib/libsafestring.a
+LD         = g++ 
 RM         = @rm
 

--- a/hipserver/Server/hsrequest.cpp
+++ b/hipserver/Server/hsrequest.cpp
@@ -107,7 +107,7 @@ request_table_status_t find_request_in_table(int transaction, hsmessage_t *resul
 {
 	request_table_status_t status = RTS_EOF;
 
-	assert(result);
+	assert(result); // no side effect
 
 	if (request_table.find(transaction) != request_table.end())
 	{

--- a/hipserver/Server/hssigs.c
+++ b/hipserver/Server/hssigs.c
@@ -176,7 +176,7 @@ static void sighandler_hs_endall(int32_t sigNum)
 		struct AppMsg msg;
 		msg.command = TERM_APP_CMD;
 		msg.transaction = 0;
-		memset(msg.pdu, 0, TPPDU_MAX_FRAMELEN);
+		memset_s(msg.pdu, TPPDU_MAX_FRAMELEN, 0);
 		snd_msg_to_app(&msg);
 		dbgp_logdbg("TERM_APP_CMD sent, not awaiting response...\n");
 	}

--- a/hipserver/Server/hssubscribe.cpp
+++ b/hipserver/Server/hssubscribe.cpp
@@ -119,11 +119,11 @@ bool Subscription::AddressMatch(uint8_t *address)
 	// 1011 1111  mask off field device in burst mode bit
 
 	uint8_t a1[TPHDR_ADDRLEN_UNIQ];
-	memcpy(a1, address, TPHDR_ADDRLEN_UNIQ);
+	memcpy_s(a1, TPHDR_ADDRLEN_UNIQ, address, TPHDR_ADDRLEN_UNIQ);
 	a1[0] &= 0xBF;
 
 	uint8_t a2[TPHDR_ADDRLEN_UNIQ];
-	memcpy(a2, UniqueID, TPHDR_ADDRLEN_UNIQ);
+	memcpy_s(a2, TPHDR_ADDRLEN_UNIQ, UniqueID, TPHDR_ADDRLEN_UNIQ);
 	a2[0] &= 0xBF;
 
 	bool match = (memcmp(a1, a2, TPHDR_ADDRLEN_UNIQ)==0);
@@ -132,7 +132,7 @@ bool Subscription::AddressMatch(uint8_t *address)
 
 void Subscription::SetAddress(const uint8_t *address)
 {
-  memcpy(UniqueID, address, TPHDR_ADDRLEN_UNIQ);
+  memcpy_s(UniqueID, TPHDR_ADDRLEN_UNIQ, address, TPHDR_ADDRLEN_UNIQ);
 }
 
 bool Subscription::IsBroadcastAddress()
@@ -423,11 +423,11 @@ bool is_attached(const uint8_t *a)
   {
     TpPdu record(*itr);
 
-    int len = 5;
+    const int len = 5;
     uint8_t buf1[5];
     uint8_t buf2[5];
-    memcpy(buf1, record.Address(), len);
-    memcpy(buf2, a, len);
+    memcpy_s(buf1, len, record.Address(), len);
+    memcpy_s(buf2, len, a, len);
     int x = memcmp(buf1, buf2, len );
 
     if (record.AddressMatch(a)) // first request bytes are 5-byte address.

--- a/hipserver/Server/hsthreads.c
+++ b/hipserver/Server/hsthreads.c
@@ -178,7 +178,7 @@ errVal_t do_hs_setup(void)
 		struct AppMsg msg;
 		msg.command = INIT_APP_CMD;
 		msg.transaction = 0;
-		memset(msg.pdu, 0, TPPDU_MAX_FRAMELEN);
+		memset_s(msg.pdu, TPPDU_MAX_FRAMELEN, 0);
 		errval = snd_msg_to_app(&msg);
 
 		eServerState = SRVR_READY;	// open for business!

--- a/hipserver/Server/hsudp.cpp
+++ b/hipserver/Server/hsudp.cpp
@@ -185,9 +185,9 @@ void *socketThrFunc(void *thrName)
 	hartip_msg_t rspToClient;
 
 	/* Start with a clean slate */
-	memset(reqBuff, 0, sizeof(reqBuff));
-	memset(&reqFromClient, 0, sizeof(reqFromClient));
-	memset(&rspToClient, 0, sizeof(rspToClient));
+	memset_s(reqBuff, sizeof(reqBuff), 0);
+	memset_s(&reqFromClient, sizeof(reqFromClient), 0);
+	memset_s(&rspToClient, sizeof(rspToClient), 0);
 
 	sockaddr_in_t client_sockaddr;
 	uint8_t sessNum = 0;
@@ -205,7 +205,7 @@ void *socketThrFunc(void *thrName)
 		}
 
 		// Clear buffer for receiving next client request
-		memset(reqBuff, 0, sizeof(reqBuff));
+		memset_s(reqBuff, sizeof(reqBuff), 0);
 
 		errval = wait_for_client_req(reqBuff, &pduLen, &client_sockaddr);
 		if (errval != NO_ERROR)
@@ -214,7 +214,7 @@ void *socketThrFunc(void *thrName)
 			continue;
 		}
 		// Clear struct before usage
-		memset(&reqFromClient, 0, sizeof(reqFromClient));
+		memset_s(&reqFromClient, sizeof(reqFromClient), 0);
 
 		errval = parse_client_req(reqBuff, pduLen, &reqFromClient);
 		if (errval != NO_ERROR)
@@ -242,7 +242,7 @@ void *socketThrFunc(void *thrName)
 		}
 
 		// Clear struct before usage
-		memset(&rspToClient, 0, sizeof(rspToClient));
+		memset_s(&rspToClient, sizeof(rspToClient), 0);
 
 		dbgp_logdbg("#*#*#*# Server recd a ");
 
@@ -349,7 +349,7 @@ errVal_t send_rsp_to_client(hartip_msg_t *p_response,
 		uint8_t rspBuff[HS_MAX_BUFFSIZE];
 
 		/* Start with a clean slate */
-		memset(rspBuff, 0, sizeof(rspBuff));
+		memset_s(rspBuff, sizeof(rspBuff), 0);
 
 		/* Fill in the version */
 		idx = HARTIP_OFFSET_VERSION;
@@ -383,8 +383,8 @@ errVal_t send_rsp_to_client(hartip_msg_t *p_response,
 		uint16_t payloadLen = byteCount - HARTIP_HEADER_LEN;
 		if (payloadLen > 0)
 		{
-			memcpy(&rspBuff[HARTIP_HEADER_LEN], p_response->hipTPPDU,
-					payloadLen);
+			memcpy_s(&rspBuff[HARTIP_HEADER_LEN], (TPPDU_MAX_FRAMELEN - TPPDU_MAX_HDRLEN), 
+					p_response->hipTPPDU, payloadLen);
 		}
 
 		uint16_t msgLen = HARTIP_HEADER_LEN + payloadLen;
@@ -453,7 +453,7 @@ static errVal_t create_udpserver_socket(uint16_t serverPortNum,
 		}
 
 		sockaddr_in_t server_addr;
-		memset(&server_addr, 0, sizeof(server_addr));
+		memset_s(&server_addr, sizeof(server_addr), 0);
 
 		server_addr.sin_family = AF_INET;
 		server_addr.sin_addr.s_addr = htonl(INADDR_ANY);
@@ -536,7 +536,7 @@ static errVal_t handle_sess_close_req(hartip_msg_t *p_request,
 		}
 
 		/* Start with a clean slate */
-		memset(p_response, 0, sizeof(*p_response));
+		memset_s(p_response, sizeof(*p_response), 0);
 
 		hartip_hdr_t *p_reqHdr = &p_request->hipHdr;
 		hartip_hdr_t *p_rspHdr = &p_response->hipHdr;
@@ -583,7 +583,7 @@ static errVal_t handle_sess_init_req(hartip_msg_t *p_request,
 			}
 
 			/* Start with a clean slate */
-			memset(p_response, 0, sizeof(*p_response));
+			memset_s(p_response, sizeof(*p_response), 0);
 
 			hartip_hdr_t *p_reqHdr = &p_request->hipHdr;
 			hartip_hdr_t *p_rspHdr = &p_response->hipHdr;
@@ -603,8 +603,8 @@ static errVal_t handle_sess_init_req(hartip_msg_t *p_request,
 			/* Fill in the payload, if long enough */
 			if (payloadLen >= HARTIP_SESS_INIT_PYLD_LEN)
 			{
-				memcpy(p_response->hipTPPDU, p_request->hipTPPDU,
-				HARTIP_SESS_INIT_PYLD_LEN);
+				memcpy_s(p_response->hipTPPDU, HARTIP_MAX_PYLD_LEN, 
+					p_request->hipTPPDU, HARTIP_SESS_INIT_PYLD_LEN);
 				p_rspHdr->byteCount += HARTIP_SESS_INIT_PYLD_LEN;
 
 				/* First byte of payload should be set to Primary Master */
@@ -669,8 +669,8 @@ static errVal_t handle_sess_init_req(hartip_msg_t *p_request,
 				dbgp_hs("Current Session #%d\n", thisSess);
 
 
-				memcpy(&pCurrentSession->clientAddr, &client_addr,
-						sizeof(client_addr));
+				memcpy_s(&pCurrentSession->clientAddr, sizeof(hartip_session_t::clientAddr), 
+						&client_addr, sizeof(client_addr));
 				pCurrentSession->id = HARTIP_SESSION_ID_OK;
 				int32_t sessSig = SIG_INACTIVITY_TIMER(thisSess);
 
@@ -736,7 +736,7 @@ static errVal_t handle_keepalive_req(hartip_msg_t *p_request,
 		}
 
 		/* Start with a clean slate */
-		memset(p_response, 0, sizeof(*p_response));
+		memset_s(p_response, sizeof(*p_response), 0);
 
 		hartip_hdr_t *p_reqHdr = &p_request->hipHdr;
 		hartip_hdr_t *p_rspHdr = &p_response->hipHdr;
@@ -820,8 +820,8 @@ static errVal_t handle_token_passing_req(hartip_msg_t *p_request, uint8_t sessNu
 
 			/* Start with a clean slate */
 			AppMsg txMsg;
-			memset(&txMsg, 0, APP_MSG_SIZE);
-			memcpy(txMsg.pdu, p_request->hipTPPDU, sizeof(p_request->hipTPPDU));
+			memset_s(&txMsg, APP_MSG_SIZE, 0);
+			memcpy_s(txMsg.pdu, TPPDU_MAX_FRAMELEN, p_request->hipTPPDU, sizeof(p_request->hipTPPDU));
 			txMsg.transaction = (sessNum << 16);
 			txMsg.transaction += hsMsg.message.hipHdr.seqNum; // client # + HART-IP sequence number
 
@@ -976,7 +976,7 @@ static errVal_t parse_client_req(uint8_t *p_reqBuff, ssize_t lenPdu,
 		}
 
 		/* Start with a clean slate */
-		memset(p_parsedReq, 0, sizeof(*p_parsedReq));
+		memset_s(p_parsedReq, sizeof(*p_parsedReq), 0);
 
 		hartip_hdr_t *p_clientMsgHdr = &p_parsedReq->hipHdr;
 
@@ -1049,7 +1049,7 @@ static errVal_t parse_client_req(uint8_t *p_reqBuff, ssize_t lenPdu,
 
 		if (payloadLen > 0)
 		{
-			memcpy(p_parsedReq->hipTPPDU, &p_reqBuff[HARTIP_HEADER_LEN],
+			memcpy_s(p_parsedReq->hipTPPDU, TPPDU_MAX_FRAMELEN, &p_reqBuff[HARTIP_HEADER_LEN],
 					payloadLen);
 		}
 	} while (FALSE);
@@ -1119,7 +1119,7 @@ static errVal_t wait_for_client_req(uint8_t *p_reqBuff, ssize_t *p_lenPdu,
 			}  // select()
 
 			socklen_t socklen = sizeof(*p_client_sockaddr);
-			memset(p_client_sockaddr, 0, socklen);
+			memset_s(p_client_sockaddr, socklen, 0);
 
 			*p_lenPdu = recvfrom(pCurrentSession->server_sockfd, p_reqBuff,
 			HARTIP_MAX_PYLD_LEN, 0, (struct sockaddr *) p_client_sockaddr,

--- a/hipserver/Server/main.c
+++ b/hipserver/Server/main.c
@@ -45,6 +45,9 @@
 
 #include "serverstate.h"
 
+#include "safe_lib.h"
+#include "snprintf_s.h"
+
 enum ServerState eServerState = SRVR_INIT;
 enum AppState eAppState = APP_STOP;
 enum AppLaunch eAppLaunch = LNCH_MANUAL;
@@ -165,11 +168,11 @@ uint8_t process_command_line(int argc, char* argv[])
 
   for (i; i < argc; i++)
   {
-    strcat(AppCommandLine, argv[i]);
-    strcat(AppCommandLine, " ");
+    strcat_s(AppCommandLine, sizeof(AppCommandLine), argv[i]);
+    strcat_s(AppCommandLine, sizeof(AppCommandLine), " ");
   }
 
-  if (strlen(AppCommandLine)+1 > sizeof(AppCommandLine))
+  if (strnlen_s(AppCommandLine, sizeof(AppCommandLine))+1 > sizeof(AppCommandLine))
   {
     printf("Command line arguments are too large\n");
     exit(1);
@@ -362,7 +365,7 @@ int32_t main(int argc, char *argv[])
   uint8_t errval = process_command_line(argc, argv);
 
   eServerState = SRVR_INIT;
-  if (strlen(AppCommandLine) > 0)
+  if (strnlen_s(AppCommandLine, sizeof(AppCommandLine)) > 0)
   {
     // a command line for the APP is provided
     eAppLaunch = LNCH_AUTO;  // server will launch APP automatically


### PR DESCRIPTION
…developed by Intel and Cisco in the repository safestringlib (MIT license) found here: https://github.com/intel/safestringlib. These protect against buffer overflow in C Standard Library functions such as: memcpy, memset, strcpy, strncpy, and sprintf.

This and the previous commit are made in response to a reported vulnerability described by CVE ID CVE-2020-16209, where an unchecked memory transfer in the IP interface could possibly overflow an internal buffer.