### PR TITLE
Converts PSK to binary for SSL/TLS

### DIFF
--- a/hipserver/Realtime/toolutils.c
+++ b/hipserver/Realtime/toolutils.c
@@ -158,6 +158,34 @@ errVal_t open_toolLog(void)
   return (errval);
 }
 
+static inline int cval(char c)
+{
+	if (c >= 'a') return c-'a'+0x0a;
+	if (c >= 'A') return c-'A'+0x0a;
+	return c -'0';
+}
+
+static bool isHexDigit(char c) 
+{
+  if ((c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f')) 
+  {
+      return true;
+  }
+  return false;
+}
+
+/* return value: number of bytes in out, <=0 if error */
+int hex2bin(char *str, uint8_t *out)
+{
+	int i;
+	for (i = 0; str[i] && str[i+1]; i+=2) 
+  {
+    if (!isHexDigit(str[i])&& !isHexDigit(str[i+1]))
+      return -1;
+    out[i/2] = (cval(str[i])<<4) + cval(str[i+1]);
+	}
+	return i/2;
+}
 
 void print_hexbytes(uint8_t *bytes, uint8_t numBytes, FILE *fptr)
 {

--- a/hipserver/Realtime/toolutils.h
+++ b/hipserver/Realtime/toolutils.h
@@ -53,6 +53,7 @@ void close_logfile(FILE *p_filePtr);
 void close_toolLog(void);
 errVal_t open_logfile(FILE **pp_filePtr, char *p_fileName);
 errVal_t open_toolLog(void);
+int hex2bin(char *str, uint8_t *out);
 void print_hexbytes(uint8_t *bytes, uint8_t numBytes, FILE *p_filePtr);
 void print_to_both(FILE *p_filePtr, const char *format, ...);
 void print_to_log(FILE *p_filePtr, const char *format, ...);

--- a/hipserver/Server/onetcpprocessor.cpp
+++ b/hipserver/Server/onetcpprocessor.cpp
@@ -30,6 +30,7 @@
 #include "hsauditlog.h"
 #include "hssecurityconfiguration.h"
 #include "hsnetworkmanager.h"
+#include "toolutils.h"
 
 int srp_server_param_cb(SSL *s, int *ad, void *arg);
 unsigned int psk_out_of_bound_serv_cb(SSL *ssl, const char *id, unsigned char *psk, unsigned int max_psk_len);
@@ -495,7 +496,8 @@ HARTIPConnection *OneTcpProcessor::GetSession()
 unsigned int psk_out_of_bound_serv_cb(SSL *ssl, const char *id, unsigned char *psk, unsigned int max_psk_len)
 {
     unsigned int retVal = 0;
-	
+	char *psk_key;
+
     SlotMap& slots = SecurityConfigurationTable::Instance()->Slots();
     SlotMap::iterator itr;
 
@@ -526,9 +528,9 @@ unsigned int psk_out_of_bound_serv_cb(SSL *ssl, const char *id, unsigned char *p
     }
     else
     {
-        memcpy_s(psk, max_psk_len, (unsigned char*)pSlot->m_keyVal.data(), pSlot->m_keyVal.size());
-  print_to_both(p_toolLogPtr, "SSL CTX PSK Identity Hint: %s \n", SSL_get_psk_identity_hint(ssl));
         retVal = pSlot->m_keyVal.size();
+		psk_key = (char *) pSlot->m_keyVal.data();
+		retVal = hex2bin(psk_key,psk); // convert hex string to binary
 		SecurityConfigurationTable::Instance()->AddConnection(ssl, itr->first);
     }
     return retVal;


### PR DESCRIPTION
Adds utility functions to convert hexadecimal string representations into binary byte arrays. This change updates the `psk_out_of_bound_serv_cb` function to utilize this conversion, ensuring that Pre-Shared Keys (PSK) are correctly processed and supplied in their binary format for SSL/TLS connections. This is crucial for proper security configuration and handshake operations.

See email traffic with Paran